### PR TITLE
fix: add essential missing run alias

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -40,9 +40,10 @@ import (
 // runCmd represents the run command
 
 var runCmd = &cobra.Command{
-	Use:   "run",
-	Args:  cobra.ArbitraryArgs,
-	Short: "Run a jenkins job",
+	Use:     "run",
+	Aliases: []string{"honk"},
+	Args:    cobra.ArbitraryArgs,
+	Short:   "Run a jenkins job",
 	Long: `Run a jenkins job based on the current git repo and branch.
 
 	Otherwise, you can specify a job to be run.


### PR DESCRIPTION
Essential workflow update to add a `honk` alias, allowing the main flow of running a job to be `goose honk`